### PR TITLE
Updated multilingual for current Jekyll version on Github Pages (3.0.3)

### DIFF
--- a/_includes/blocks/ad.md
+++ b/_includes/blocks/ad.md
@@ -1,9 +1,0 @@
-{% if page.lang == 'en' %}
-### Am I eligible to get insurance through the Marketplace?'
-Yes you are! [sign up today](http://example.com)
-{% endif %}
-
-{% if page.lang == 'es' %}
-### ¿Soy elegible para obtener seguro a través de la Plataforma?
-Si eres! [Regístrate hoy](http://example.com)
-{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,13 @@ translations:
                 <li><a href='{{site.baseurl}}{{post.url}}' {% if page.lang == i.key %}class='active'{% endif %}>{{i.name}}</a></li>
               {% endif %}
             {% endfor %}
+
+            {% for post in site.pages %}
+              {% if {{page.date}} == {{post.date}} and {{post.lang}} == {{i.key}} %}
+                <li><a href='{{site.baseurl}}{{post.url}}' {% if page.lang == i.key %}class='active'{% endif %}>{{i.name}}</a></li>
+              {% endif %}
+            {% endfor %}
+
           {% endfor %}
         </ul>
       </div>
@@ -50,12 +57,6 @@ translations:
               {% endif %}
             {% endfor %}
           </ul>
-        </div>
-        <div class='block'>
-          <div class='inner'>
-            {% capture ad %}{% include blocks/ad.md %}{% endcapture %}
-            {{ ad | markdownify }}
-          </div>
         </div>
       </div>
       <div class='main fl'>

--- a/en/index.html
+++ b/en/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
 lang: en
+date: 0001-01-01
 title: Hello
-permalink: /en
 ---

--- a/es/index.html
+++ b/es/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 lang: es
+date: 0001-01-01
 title: ¡Hola
-permalink: /es
 ---
 


### PR DESCRIPTION
The permalink feature was breaking the JS redirect.
I took the liberty to also transform the index posts into pages.
I did a quick fix to make the language switcher work.
And (cheeky me) I also removed the ad block. 
